### PR TITLE
Validate JWT/DB configuration at startup and clean up controllers

### DIFF
--- a/API/Controllers/ExerciseController.cs
+++ b/API/Controllers/ExerciseController.cs
@@ -3,11 +3,10 @@ using DAL;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
-namespace API
-{ 
-    [ApiController]
-    [Route("[controller]")]
+namespace API;
 
+[ApiController]
+[Route("[controller]")]
 public class ExercisesController : ControllerBase
 {
     private readonly MyDbContext _context;
@@ -17,13 +16,11 @@ public class ExercisesController : ControllerBase
         _context = context;
     }
 
-    
     [HttpGet]
     public async Task<ActionResult<IEnumerable<Exercise>>> GetExercises()
     {
         var exercises = await _context.Exercise.ToListAsync();
-        
+
         return Ok(exercises);
     }
-}
 }

--- a/API/Controllers/TrainingController.cs
+++ b/API/Controllers/TrainingController.cs
@@ -1,10 +1,7 @@
-using System.IdentityModel.Tokens.Jwt;
 using Business.Entities;
-using DAL;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
-using Business;
 using Business.Dtos.EntityDtos;
 using Business.Dtos.RequestDtos;
 using Business.Exceptions;
@@ -16,12 +13,10 @@ namespace API.Controllers
     [Route("[controller]")]
     public class TrainingController : ControllerBase
     {
-        private readonly MyDbContext _context;
         private readonly ITrainingService _trainingService;
 
-        public TrainingController(MyDbContext context, ITrainingService trainingService)
+        public TrainingController(ITrainingService trainingService)
         {
-            _context = context;
             _trainingService = trainingService;
         }
 

--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -9,7 +9,7 @@ namespace API;
 [Route("[controller]")]
 public class UserController : ControllerBase
 {
-    IUserService _userService;
+    private readonly IUserService _userService;
 
     public UserController(IUserService userService)
     {

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -25,7 +25,25 @@ builder.Services.AddCors(options =>
 });
 
 var jwtSettings = builder.Configuration.GetSection("JwtSettings");
-var secretKey = Encoding.UTF8.GetBytes("this_is_a_secret_key_that_is_long_enough");
+var jwtSecret = jwtSettings["Secret"];
+if (string.IsNullOrWhiteSpace(jwtSecret))
+{
+    throw new InvalidOperationException("JwtSettings:Secret is not configured.");
+}
+
+var jwtIssuer = jwtSettings["Issuer"];
+if (string.IsNullOrWhiteSpace(jwtIssuer))
+{
+    throw new InvalidOperationException("JwtSettings:Issuer is not configured.");
+}
+
+var jwtAudience = jwtSettings["Audience"];
+if (string.IsNullOrWhiteSpace(jwtAudience))
+{
+    throw new InvalidOperationException("JwtSettings:Audience is not configured.");
+}
+
+var secretKey = Encoding.UTF8.GetBytes(jwtSecret);
 
 // Add Authentication services
 builder.Services.AddAuthentication(options =>
@@ -42,8 +60,8 @@ builder.Services.AddAuthentication(options =>
             ValidateLifetime = true,
             ClockSkew = TimeSpan.Zero,
             ValidateIssuerSigningKey = true,
-            ValidIssuer = "your_issuer",
-            ValidAudience = "your_audience",
+            ValidIssuer = jwtIssuer,
+            ValidAudience = jwtAudience,
             IssuerSigningKey = new SymmetricSecurityKey(secretKey)
         };
     });
@@ -62,7 +80,8 @@ builder.Services.AddSwaggerGen(c =>
 });
 
 // Add DbContext
-string defaultconnection = builder.Configuration.GetConnectionString("DefaultConnection");
+string defaultconnection = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("ConnectionStrings:DefaultConnection is not configured.");
 builder.Services.AddDbContext<MyDbContext>(options =>
     options.UseMySql(defaultconnection,
         ServerVersion.AutoDetect(defaultconnection),


### PR DESCRIPTION
### Motivation
- Ensure the application fails fast when critical JWT settings are missing by replacing hardcoded values with configuration-backed values.  
- Prevent startup with a missing database connection string by validating `ConnectionStrings:DefaultConnection` early.  
- Remove unused controller dependencies and improve consistency of dependency injection and formatting.  

### Description
- Updated `API/Program.cs` to read `JwtSettings:Secret`, `JwtSettings:Issuer`, and `JwtSettings:Audience` from configuration and to throw `InvalidOperationException` when any are not configured.  
- Replaced the hardcoded signing key and issuer/audience in `TokenValidationParameters` with `jwtSecret`, `jwtIssuer`, and `jwtAudience`, and added a null-coalescing check that throws if `DefaultConnection` is missing.  
- Cleaned up controllers by marking `_userService` as `readonly` in `UserController`, removing the unused `MyDbContext` injection and associated usings from `TrainingController`, and normalizing `ExercisesController` to a file-scoped namespace and consistent formatting.  

### Testing
- No automated tests were executed for these changes.  
- Manual build/run checks were not recorded as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663e0c8ce08332982a8add221f086c)